### PR TITLE
fix(ipc): support Rayforce wire protocol v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -265,6 +265,7 @@
     "vscode:prepublish": "npm run compile",
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
+    "test:ipc": "node scripts/test-ipc.js",
     "package": "vsce package"
   },
   "devDependencies": {

--- a/scripts/test-ipc.js
+++ b/scripts/test-ipc.js
@@ -1,0 +1,220 @@
+#!/usr/bin/env node
+/**
+ * Integration test for the wire protocol v3 IPC client.
+ *
+ * Spawns a local rayforce instance (from $RAYFORCE_BIN or PATH) and runs the
+ * compiled client (out/rayforceIpc.js) against it.  Run `npm run compile`
+ * first, then `npm run test:ipc`.
+ */
+
+const { spawn } = require('child_process');
+const net = require('net');
+const path = require('path');
+
+const { RayforceIpcClient, AuthRequiredError, isError } = require(path.join(__dirname, '..', 'out', 'rayforceIpc.js'));
+
+const RAYFORCE_BIN = process.env.RAYFORCE_BIN || 'rayforce';
+const HOST = '127.0.0.1';
+
+let passed = 0;
+let failed = 0;
+
+function ok(name, cond, detail) {
+    if (cond) {
+        passed++;
+        console.log(`  ok    ${name}`);
+    } else {
+        failed++;
+        console.log(`  FAIL  ${name}${detail ? ` — ${detail}` : ''}`);
+    }
+}
+
+function show(v) {
+    return typeof v === 'symbol' ? v.toString() : JSON.stringify(v, (_, x) => (typeof x === 'bigint' ? `${x}n` : x));
+}
+
+function spawnRayforce(port, extraArgs) {
+    const proc = spawn(RAYFORCE_BIN, ['-p', String(port), ...(extraArgs || [])], {
+        stdio: ['ignore', 'ignore', 'inherit']
+    });
+    proc.on('error', (err) => {
+        console.error(`Cannot start ${RAYFORCE_BIN}: ${err.message} (set RAYFORCE_BIN to the binary path)`);
+        process.exit(2);
+    });
+    return proc;
+}
+
+function waitForPort(port, timeoutMs) {
+    const deadline = Date.now() + timeoutMs;
+    return new Promise((resolve, reject) => {
+        const attempt = () => {
+            const s = net.connect(port, HOST);
+            s.once('connect', () => { s.destroy(); resolve(); });
+            s.once('error', () => {
+                s.destroy();
+                if (Date.now() > deadline) reject(new Error(`rayforce did not listen on ${port} within ${timeoutMs}ms`));
+                else setTimeout(attempt, 100);
+            });
+        };
+        attempt();
+    });
+}
+
+async function testValues(client) {
+    const eq = async (expr, expect, name) => {
+        const got = await client.execute(expr);
+        ok(name || expr, show(got) === show(expect), `got ${show(got)}, want ${show(expect)}`);
+    };
+
+    // Atoms
+    await eq('42', 42n);
+    await eq('3.5', 3.5);
+    await eq('true', true);
+    await eq('"hello"', 'hello');
+    await eq('"пример юникода"', 'пример юникода', 'utf8 string');
+    await eq('(println "")', null, 'null result (wire null marker)');
+    await eq('0Nl', null, 'typed null atom');
+
+    const sym = await client.execute("'foo");
+    ok("'foo symbol", typeof sym === 'symbol' && Symbol.keyFor(sym) === 'foo', show(sym));
+
+    const date = await client.execute('2024.03.15');
+    ok('date atom', date && date._type === 'date', show(date));
+
+    const ts = await client.execute('2024.03.15D12:30:45.123456789');
+    ok('timestamp atom', ts && ts._type === 'timestamp' && ts.value === 763821045123456789n, show(ts));
+
+    // Vectors and lists
+    await eq('[1 2 3]', [1n, 2n, 3n]);
+    await eq('[1.5 2.5]', [1.5, 2.5]);
+    await eq('(til 4)', [0n, 1n, 2n, 3n]);
+
+    const list = await client.execute('(list 1 "a" \'b)');
+    ok('mixed list', Array.isArray(list) && list.length === 3 && list[0] === 1n && list[1] === 'a', show(list));
+
+    // Dict
+    const dict = await client.execute("(dict ['a 'b] [1 2])");
+    ok('dict', dict && dict._type === 'dict' && Array.isArray(dict.keys) && dict.keys.length === 2, show(dict && dict.keys));
+
+    // Table
+    const table = await client.execute("(table ['a 'b] (list [1 2 3] [4.5 5.5 6.5]))");
+    ok('table columns', table && table._type === 'table' && table.columns.join(',') === 'a,b', show(table && table.columns));
+    ok('table values', table && table.values.length === 2 && table.values[0].length === 3 && table.values[1][2] === 6.5,
+        show(table && table.values));
+
+    // Compressed response (serialized size is far above the 2000-byte threshold)
+    const big = await client.execute('(til 100000)');
+    ok('compressed vector length', Array.isArray(big) && big.length === 100000, `len ${big && big.length}`);
+    ok('compressed vector data', Array.isArray(big) && big[0] === 0n && big[99999] === 99999n,
+        Array.isArray(big) ? `ends ${show(big[99999])}` : show(big));
+
+    const bigTable = await client.execute("(table ['n 's] (list (til 5000) (map (fn [x] 'sym) (til 5000))))");
+    ok('compressed table', bigTable && bigTable._type === 'table' && bigTable.values[0].length === 5000,
+        show(bigTable && bigTable.columns));
+
+    // Builtins and lambdas
+    const builtin = await client.execute('sum');
+    ok('builtin by name', builtin && builtin._type === 'function' && builtin.name === 'sum', show(builtin));
+
+    const lambda = await client.execute('(fn [x] x)');
+    ok('lambda', lambda && lambda._type === 'function' && lambda.name === null, show(lambda));
+
+    // Errors: packed ASCII code
+    const typeErr = await client.execute("(+ 1 'x)");
+    ok("type error code", isError(typeErr) && typeErr.code === 'type', show(typeErr));
+
+    const parseErr = await client.execute(')))');
+    ok("parse error code (REPL fallback relies on this)", isError(parseErr) && parseErr.code === 'parse', show(parseErr));
+
+    // Async fire-and-forget then read back
+    await client.executeAsync('(set g_ipc_test 7)');
+    const asyncVal = await client.execute('g_ipc_test');
+    ok('async set + sync read', asyncVal === 7n, show(asyncVal));
+
+    // The exact queries the Environment panel sends: names and types must
+    // arrive in the same order so the panel can pair them up
+    const envNames = await client.execute('(key (env 0))');
+    const envTypes = await client.execute('(map type (value (env 0)))');
+    ok('env names/types pair up', Array.isArray(envNames) && Array.isArray(envTypes) &&
+        envNames.length === envTypes.length && envNames.length > 0,
+        `names ${envNames && envNames.length}, types ${envTypes && envTypes.length}`);
+
+    const envIdx = Array.isArray(envNames)
+        ? envNames.findIndex((s) => typeof s === 'symbol' && Symbol.keyFor(s) === 'g_ipc_test')
+        : -1;
+    ok('user var has aligned type', envIdx >= 0 && typeof envTypes[envIdx] === 'symbol' &&
+        Symbol.keyFor(envTypes[envIdx]) === 'i64',
+        envIdx >= 0 ? `type ${show(envTypes[envIdx])}` : 'g_ipc_test not found');
+
+    // The exact preview wrapper the REPL panel sends for large results
+    const wrapper = "((fn [] (let __pr_r (table ['n] (list (til 50)))) (let __pr_t (type __pr_r)) (let __pr_c (if (or (== __pr_t 'TABLE) (== __pr_t 'LIST)) (count __pr_r) 0)) (list __pr_c __pr_t (if (> __pr_c 10) (take __pr_r [0 10]) __pr_r))))";
+    const wrapped = await client.execute(wrapper);
+    ok('REPL preview wrapper', Array.isArray(wrapped) && wrapped.length === 3 && Number(wrapped[0]) === 50 &&
+        wrapped[2] && wrapped[2]._type === 'table' && wrapped[2].values[0].length === 10, show(wrapped && wrapped[0]));
+}
+
+async function testAuth(port) {
+    const noCreds = new RayforceIpcClient(HOST, port);
+    try {
+        await noCreds.connect(3000);
+        ok('auth: rejected without password', false, 'connect unexpectedly succeeded');
+        noCreds.disconnect();
+    } catch (err) {
+        ok('auth: rejected without password', err instanceof AuthRequiredError, err.message);
+    }
+
+    const wrongCreds = new RayforceIpcClient(HOST, port);
+    try {
+        await wrongCreds.connect(3000, { password: 'wrong' });
+        ok('auth: rejected with wrong password', false, 'connect unexpectedly succeeded');
+        wrongCreds.disconnect();
+    } catch (err) {
+        ok('auth: rejected with wrong password', /rejected|closed/i.test(err.message), err.message);
+    }
+
+    const goodCreds = new RayforceIpcClient(HOST, port);
+    try {
+        await goodCreds.connect(3000, { password: 'testpw' });
+        const v = await goodCreds.execute('(+ 1 2)');
+        ok('auth: accepted with password', v === 3n, show(v));
+    } catch (err) {
+        ok('auth: accepted with password', false, err.message);
+    } finally {
+        goodCreds.disconnect();
+    }
+}
+
+async function main() {
+    const port = 5000 + Math.floor(Math.random() * 2000);
+    const authPort = port + 1;
+
+    console.log(`Starting ${RAYFORCE_BIN} on :${port} (plain) and :${authPort} (auth)...`);
+    const server = spawnRayforce(port);
+    const authServer = spawnRayforce(authPort, ['-u', 'testpw']);
+
+    try {
+        await waitForPort(port, 10000);
+        await waitForPort(authPort, 10000);
+
+        const client = new RayforceIpcClient(HOST, port);
+        await client.connect(5000);
+        console.log('Connected (handshake v3).');
+
+        await testValues(client);
+        client.disconnect();
+
+        console.log('Auth handshake:');
+        await testAuth(authPort);
+    } finally {
+        server.kill();
+        authServer.kill();
+    }
+
+    console.log(`\n${passed} passed, ${failed} failed`);
+    process.exit(failed === 0 ? 0 : 1);
+}
+
+main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});

--- a/src/prettyPrint.ts
+++ b/src/prettyPrint.ts
@@ -3,7 +3,7 @@
  * Renders Rayforce types as beautiful HTML for the REPL webview
  */
 
-import { RayforceValue, RayforceTable, RayforceDict, RayforceError, RayforceDate, RayforceTime, RayforceTimestamp } from './rayforceIpc';
+import { RayforceValue, RayforceTable, RayforceDict, RayforceError, RayforceFunction, RayforceDate, RayforceTime, RayforceTimestamp } from './rayforceIpc';
 
 // ============================================================================
 // Configuration
@@ -38,9 +38,9 @@ const DEFAULT_CONFIG: PrettyPrintConfig = {
 // Type Detection
 // ============================================================================
 
-export type RayforceTypeName = 
-    | 'Null' | 'B8' | 'U8' | 'I16' | 'I32' | 'I64' | 'F64'
-    | 'C8' | 'Symbol' | 'Date' | 'Time' | 'Timestamp' | 'GUID'
+export type RayforceTypeName =
+    | 'Null' | 'B8' | 'U8' | 'I16' | 'I32' | 'I64' | 'F32' | 'F64'
+    | 'String' | 'Symbol' | 'Date' | 'Time' | 'Timestamp' | 'GUID'
     | 'List' | 'Dict' | 'Table' | 'Error' | 'Lambda' | 'Unknown';
 
 export function detectType(value: RayforceValue): RayforceTypeName {
@@ -51,7 +51,7 @@ export function detectType(value: RayforceValue): RayforceTypeName {
         if (Number.isInteger(value)) return 'I32';
         return 'F64';
     }
-    if (typeof value === 'string') return 'C8';
+    if (typeof value === 'string') return 'String';
     if (typeof value === 'symbol') return 'Symbol';
     if (value instanceof Date) return 'Timestamp';
     if (Array.isArray(value)) {
@@ -62,6 +62,7 @@ export function detectType(value: RayforceValue): RayforceTypeName {
         if (value._type === 'table') return 'Table';
         if (value._type === 'dict') return 'Dict';
         if (value._type === 'error') return 'Error';
+        if (value._type === 'function') return 'Lambda';
         if (value._type === 'date') return 'Date';
         if (value._type === 'time') return 'Time';
         if (value._type === 'timestamp') return 'Timestamp';
@@ -314,6 +315,9 @@ function formatValueInner(value: RayforceValue, config: PrettyPrintConfig, depth
     if (typeof value === 'object' && '_type' in value) {
         if (value._type === 'error') {
             return formatError(value as RayforceError);
+        }
+        if (value._type === 'function') {
+            return formatFunction(value as RayforceFunction, config, depth);
         }
         if (value._type === 'table') {
             return formatTableHtml(value as RayforceTable, config, pagination);
@@ -594,16 +598,22 @@ function formatArray(arr: RayforceValue[], config: PrettyPrintConfig, depth: num
 }
 
 function formatError(error: RayforceError): string {
-    const codeNames: { [key: number]: string } = {
-        1: 'INIT', 2: 'PARSE', 3: 'EVAL', 4: 'FORMAT', 5: 'TYPE',
-        6: 'LENGTH', 7: 'ARITY', 8: 'INDEX', 9: 'HEAP', 10: 'IO',
-        11: 'SYS', 12: 'OS', 13: 'NOT_FOUND', 14: 'NOT_EXIST',
-        15: 'NOT_IMPL', 16: 'NOT_SUPPORTED'
-    };
-    
-    const codeName = codeNames[error.code] || `E${error.code}`;
-    
-    return `<span class="rf-error"><span class="rf-error-code">${codeName}</span>${escapeHtml(error.message)}</span>`;
+    const codeName = (error.code || 'error').toUpperCase();
+    // v3 puts only the packed code on the wire; skip the message when it
+    // just repeats the code
+    const detail = error.message && error.message !== error.code ? escapeHtml(error.message) : '';
+
+    return `<span class="rf-error"><span class="rf-error-code">${escapeHtml(codeName)}</span>${detail}</span>`;
+}
+
+function formatFunction(fn: RayforceFunction, config: PrettyPrintConfig, depth: number): string {
+    if (fn.name) {
+        return `<span class="rf-lambda">${escapeHtml(fn.name)}</span>`;
+    }
+    const params = Array.isArray(fn.params)
+        ? formatValueInner(fn.params, config, depth + 1)
+        : '';
+    return `<span class="rf-lambda">fn</span>${params}`;
 }
 
 function formatDictHtml(dict: RayforceDict, config: PrettyPrintConfig, depth: number): string {
@@ -815,6 +825,10 @@ export function formatValueText(value: RayforceValue, config: PrettyPrintConfig 
     }
     if (typeof value === 'object' && '_type' in value) {
         if (value._type === 'error') return `'${(value as RayforceError).message}`;
+        if (value._type === 'function') {
+            const fn = value as RayforceFunction;
+            return fn.name || 'fn';
+        }
         if (value._type === 'table') return formatTableText(value as RayforceTable, config);
         if (value._type === 'dict') {
             const dict = value as RayforceDict;

--- a/src/rayforceIpc.ts
+++ b/src/rayforceIpc.ts
@@ -1,6 +1,9 @@
 /**
  * Rayforce IPC Client for TypeScript
- * Native implementation of Rayforce protocol without external executable
+ * Native implementation of the Rayforce wire protocol (version 3)
+ * without external executable.
+ *
+ * Wire reference: rayforce src/store/serde.{h,c} and src/core/ipc.c.
  */
 
 import * as net from 'net';
@@ -9,7 +12,8 @@ import * as net from 'net';
 // Constants
 // ============================================================================
 
-const RAYFORCE_VERSION = 1;
+// RAY_SERDE_WIRE_VERSION — the server refuses any other version at handshake
+const RAYFORCE_WIRE_VERSION = 3;
 const SERDE_PREFIX = 0xcefadefa;
 
 // Message types
@@ -17,43 +21,35 @@ const MSG_TYPE_ASYNC = 0;
 const MSG_TYPE_SYNC = 1;
 const MSG_TYPE_RESP = 2;
 
-// Data types
+// IPC header flags
+const IPC_FLAG_COMPRESSED = 0x01;
+
+// Atom flags byte (v3: every atom is type + flags + value bytes)
+const ATOM_FLAG_NULL = 0x01; // typed-null marker
+
+// Data types (wire v3 ids; atoms use the negated id)
 const TYPE_LIST = 0;
 const TYPE_B8 = 1;
 const TYPE_U8 = 2;
 const TYPE_I16 = 3;
 const TYPE_I32 = 4;
 const TYPE_I64 = 5;
-const TYPE_SYMBOL = 6;
-const TYPE_DATE = 7;
-const TYPE_TIME = 8;
-const TYPE_TIMESTAMP = 9;
-const TYPE_F64 = 10;
+const TYPE_F32 = 6;
+const TYPE_F64 = 7;
+const TYPE_DATE = 8;
+const TYPE_TIME = 9;
+const TYPE_TIMESTAMP = 10;
 const TYPE_GUID = 11;
-const TYPE_C8 = 12;
+const TYPE_SYMBOL = 12;
+const TYPE_STR = 13;
 const TYPE_TABLE = 98;
 const TYPE_DICT = 99;
 const TYPE_LAMBDA = 100;
+const TYPE_UNARY = 101;
+const TYPE_BINARY = 102;
+const TYPE_VARY = 103;
 const TYPE_NULL = 126;
 const TYPE_ERR = 127;
-
-// Error codes
-const ERR_INIT = 1;
-const ERR_PARSE = 2;
-const ERR_EVAL = 3;
-const ERR_FORMAT = 4;
-const ERR_TYPE = 5;
-const ERR_LENGTH = 6;
-const ERR_ARITY = 7;
-const ERR_INDEX = 8;
-const ERR_HEAP = 9;
-const ERR_IO = 10;
-const ERR_SYS = 11;
-const ERR_OS = 12;
-const ERR_NOT_FOUND = 13;
-const ERR_NOT_EXIST = 14;
-const ERR_NOT_IMPLEMENTED = 15;
-const ERR_NOT_SUPPORTED = 16;
 
 // ============================================================================
 // Types
@@ -74,7 +70,7 @@ export interface RayforceTimestamp {
     value: bigint; // i64: nanoseconds since 2000-01-01
 }
 
-export type RayforceValue = 
+export type RayforceValue =
     | null
     | boolean
     | number
@@ -87,6 +83,7 @@ export type RayforceValue =
     | RayforceValue[]
     | RayforceTable
     | RayforceDict
+    | RayforceFunction
     | RayforceError;
 
 export interface RayforceTable {
@@ -102,10 +99,24 @@ export interface RayforceDict {
     values: RayforceValue;
 }
 
+export interface RayforceFunction {
+    _type: 'function';
+    name: string | null;    // builtin name (null for lambdas)
+    params: RayforceValue;  // lambda parameter list (null for builtins)
+}
+
 export interface RayforceError {
     _type: 'error';
-    code: number;
-    message: string;
+    code: string;    // packed ASCII code, e.g. 'type', 'parse', 'oom'
+    message: string; // same as code (v3 sends no detail text over the wire)
+}
+
+/** Thrown by connect() when the server requires credentials and none were given */
+export class AuthRequiredError extends Error {
+    constructor() {
+        super('Authentication required');
+        this.name = 'AuthRequiredError';
+    }
 }
 
 export interface IpcHeader {
@@ -123,21 +134,22 @@ export interface IpcHeader {
 
 class Serializer {
     /**
-     * Serialize a string value to Rayforce format
+     * Serialize a string value as a STR atom (the payload shape the server's
+     * sync handler evaluates as source text)
      */
     static serializeString(str: string): Buffer {
         const strBytes = Buffer.from(str, 'utf8');
         const len = strBytes.length;
-        
-        // type (1) + attrs (1) + length (8) + data
+
+        // type (1) + flags (1) + length (8) + data
         const buf = Buffer.alloc(1 + 1 + 8 + len);
         let offset = 0;
-        
-        buf.writeInt8(TYPE_C8, offset); offset += 1;
-        buf.writeUInt8(0, offset); offset += 1; // attrs
+
+        buf.writeInt8(-TYPE_STR, offset); offset += 1;
+        buf.writeUInt8(0, offset); offset += 1; // atom flags
         buf.writeBigInt64LE(BigInt(len), offset); offset += 8;
         strBytes.copy(buf, offset);
-        
+
         return buf;
     }
 
@@ -148,20 +160,75 @@ class Serializer {
         const headerSize = 16;
         const msg = Buffer.alloc(headerSize + payload.length);
         let offset = 0;
-        
+
         // Header
         msg.writeUInt32LE(SERDE_PREFIX, offset); offset += 4;
-        msg.writeUInt8(RAYFORCE_VERSION, offset); offset += 1;
+        msg.writeUInt8(RAYFORCE_WIRE_VERSION, offset); offset += 1;
         msg.writeUInt8(0, offset); offset += 1; // flags
         msg.writeUInt8(0, offset); offset += 1; // endian (little)
         msg.writeUInt8(msgtype, offset); offset += 1;
         msg.writeBigInt64LE(BigInt(payload.length), offset); offset += 8;
-        
+
         // Payload
         payload.copy(msg, offset);
-        
+
         return msg;
     }
+}
+
+// ============================================================================
+// Compression (delta + RLE, mirrors ray_ipc_decompress in core/ipc.c)
+// ============================================================================
+
+/**
+ * Decompress a compressed IPC payload: [u32 uncompressed size][RLE stream],
+ * where the RLE stream encodes a delta-coded byte sequence.  A positive i8
+ * count means "repeat next byte count times"; a non-positive count means
+ * "copy -count literal bytes".  The delta code is undone by a prefix sum.
+ */
+function decompressPayload(payload: Buffer): Buffer {
+    if (payload.length < 4) {
+        throw new Error('Compressed payload too short');
+    }
+    const uncompSize = payload.readUInt32LE(0);
+    if (uncompSize === 0 || uncompSize > 256 * 1024 * 1024) {
+        throw new Error(`Invalid uncompressed size: ${uncompSize}`);
+    }
+
+    const out = Buffer.alloc(uncompSize);
+    let si = 4;
+    let di = 0;
+
+    while (si < payload.length && di < uncompSize) {
+        const count = payload.readInt8(si); si += 1;
+        if (count > 0) {
+            if (si >= payload.length || di + count > uncompSize) {
+                throw new Error('Corrupted compressed payload');
+            }
+            out.fill(payload[si], di, di + count);
+            si += 1;
+            di += count;
+        } else {
+            const n = -count;
+            if (si + n > payload.length || di + n > uncompSize) {
+                throw new Error('Corrupted compressed payload');
+            }
+            payload.copy(out, di, si, si + n);
+            si += n;
+            di += n;
+        }
+    }
+
+    if (di !== uncompSize) {
+        throw new Error(`Decompressed size mismatch: got ${di}, expected ${uncompSize}`);
+    }
+
+    // Un-delta (prefix sum mod 256)
+    for (let i = 1; i < uncompSize; i++) {
+        out[i] = (out[i] + out[i - 1]) & 0xff;
+    }
+
+    return out;
 }
 
 // ============================================================================
@@ -251,6 +318,12 @@ class Deserializer {
         return val;
     }
 
+    readFloatLE(): number {
+        const val = this.buf.readFloatLE(this.offset);
+        this.offset += 4;
+        return val;
+    }
+
     readDoubleLE(): number {
         const val = this.buf.readDoubleLE(this.offset);
         this.offset += 8;
@@ -301,58 +374,29 @@ class Deserializer {
 
         const type = this.readInt8();
 
+        if (type === TYPE_NULL) {
+            return null;
+        }
+
+        // Atoms (negative types)
+        if (type < 0) {
+            return this.deserializeAtom(-type);
+        }
+
         switch (type) {
-            case TYPE_NULL:
-                return null;
-
-            // Atoms (negative types)
-            case -TYPE_B8:
-                return this.readInt8() !== 0;
-            
-            case -TYPE_U8:
-                return this.readUInt8();
-
-            case -TYPE_I16:
-                return this.readInt16LE();
-
-            case -TYPE_I32:
-                return this.readInt32LE();
-
-            case -TYPE_DATE:
-                return dateFromI32(this.readInt32LE());
-
-            case -TYPE_TIME:
-                return timeFromI32(this.readInt32LE());
-
-            case -TYPE_I64:
-                return this.readBigInt64LE();
-
-            case -TYPE_TIMESTAMP:
-                return timestampFromI64(this.readBigInt64LE());
-
-            case -TYPE_F64:
-                return this.readDoubleLE();
-
-            case -TYPE_SYMBOL:
-                return Symbol.for(this.readNullTerminatedString());
-
-            case -TYPE_C8:
-                return String.fromCharCode(this.readInt8());
-
-            case -TYPE_GUID:
-                return this.readBuffer(16).toString('hex');
-
             // Vectors (positive types)
             case TYPE_B8:
             case TYPE_U8:
-            case TYPE_C8:
+            case TYPE_I16:
             case TYPE_I32:
+            case TYPE_F32:
             case TYPE_DATE:
             case TYPE_TIME:
             case TYPE_I64:
             case TYPE_TIMESTAMP:
             case TYPE_F64:
             case TYPE_SYMBOL:
+            case TYPE_STR:
             case TYPE_GUID:
             case TYPE_LIST:
                 return this.deserializeVector(type);
@@ -363,11 +407,86 @@ class Deserializer {
             case TYPE_DICT:
                 return this.deserializeDict();
 
+            case TYPE_LAMBDA:
+                return this.deserializeLambda();
+
+            case TYPE_UNARY:
+            case TYPE_BINARY:
+            case TYPE_VARY:
+                return this.deserializeBuiltin();
+
             case TYPE_ERR:
                 return this.deserializeError();
 
             default:
                 throw new Error(`Unsupported type: ${type}`);
+        }
+    }
+
+    /**
+     * Deserialize an atom: flags byte + value bytes.  Flags bit 0 marks a
+     * typed null (the value bytes still carry the sentinel).
+     */
+    private deserializeAtom(base: number): RayforceValue {
+        const flags = this.readUInt8();
+        const isNull = (flags & ATOM_FLAG_NULL) !== 0;
+
+        switch (base) {
+            case TYPE_B8: {
+                const v = this.readInt8() !== 0;
+                return isNull ? null : v;
+            }
+            case TYPE_U8: {
+                const v = this.readUInt8();
+                return isNull ? null : v;
+            }
+            case TYPE_I16: {
+                const v = this.readInt16LE();
+                return isNull ? null : v;
+            }
+            case TYPE_I32: {
+                const v = this.readInt32LE();
+                return isNull ? null : v;
+            }
+            case TYPE_F32: {
+                const v = this.readFloatLE();
+                return isNull ? null : v;
+            }
+            case TYPE_F64: {
+                const v = this.readDoubleLE();
+                return isNull ? null : v;
+            }
+            case TYPE_DATE: {
+                const v = this.readInt32LE();
+                return isNull ? null : dateFromI32(v);
+            }
+            case TYPE_TIME: {
+                const v = this.readInt32LE();
+                return isNull ? null : timeFromI32(v);
+            }
+            case TYPE_I64: {
+                const v = this.readBigInt64LE();
+                return isNull ? null : v;
+            }
+            case TYPE_TIMESTAMP: {
+                const v = this.readBigInt64LE();
+                return isNull ? null : timestampFromI64(v);
+            }
+            case TYPE_SYMBOL: {
+                const s = this.readNullTerminatedString();
+                return isNull ? null : Symbol.for(s);
+            }
+            case TYPE_STR: {
+                const len = Number(this.readBigInt64LE());
+                const s = this.readBuffer(len).toString('utf8');
+                return isNull ? null : s;
+            }
+            case TYPE_GUID: {
+                const hex = this.readBuffer(16).toString('hex');
+                return isNull ? null : hex;
+            }
+            default:
+                throw new Error(`Unsupported atom type: ${-base}`);
         }
     }
 
@@ -382,11 +501,14 @@ class Deserializer {
             case TYPE_U8:
                 return Array.from(this.readBuffer(len));
 
-            case TYPE_C8:
-                return this.readBuffer(len).toString('utf8');
+            case TYPE_I16:
+                return Array.from({ length: len }, () => this.readInt16LE());
 
             case TYPE_I32:
                 return Array.from({ length: len }, () => this.readInt32LE());
+
+            case TYPE_F32:
+                return Array.from({ length: len }, () => this.readFloatLE());
 
             case TYPE_DATE:
                 return Array.from({ length: len }, () => dateFromI32(this.readInt32LE()));
@@ -405,6 +527,13 @@ class Deserializer {
 
             case TYPE_SYMBOL:
                 return Array.from({ length: len }, () => Symbol.for(this.readNullTerminatedString()));
+
+            case TYPE_STR:
+                // Each cell is an i64 length followed by raw utf8 bytes
+                return Array.from({ length: len }, () => {
+                    const slen = Number(this.readBigInt64LE());
+                    return this.readBuffer(slen).toString('utf8');
+                });
 
             case TYPE_GUID:
                 return Array.from({ length: len }, () => this.readBuffer(16).toString('hex'));
@@ -473,59 +602,9 @@ class Deserializer {
             return { value: null, typeName: 'Null' };
         }
 
-        const type = this.readInt8();
-        const typeName = this.getTypeName(type);
-
-        switch (type) {
-            case TYPE_NULL:
-                return { value: null, typeName };
-            case -TYPE_B8:
-                return { value: this.readInt8() !== 0, typeName };
-            case -TYPE_U8:
-                return { value: this.readUInt8(), typeName };
-            case -TYPE_I16:
-                return { value: this.readInt16LE(), typeName };
-            case -TYPE_I32:
-                return { value: this.readInt32LE(), typeName };
-            case -TYPE_DATE:
-                return { value: dateFromI32(this.readInt32LE()), typeName };
-            case -TYPE_TIME:
-                return { value: timeFromI32(this.readInt32LE()), typeName };
-            case -TYPE_I64:
-                return { value: this.readBigInt64LE(), typeName };
-            case -TYPE_TIMESTAMP:
-                return { value: timestampFromI64(this.readBigInt64LE()), typeName };
-            case -TYPE_F64:
-                return { value: this.readDoubleLE(), typeName };
-            case -TYPE_SYMBOL:
-                return { value: Symbol.for(this.readNullTerminatedString()), typeName };
-            case -TYPE_C8:
-                return { value: String.fromCharCode(this.readInt8()), typeName };
-            case -TYPE_GUID:
-                return { value: this.readBuffer(16).toString('hex'), typeName };
-            case TYPE_B8:
-            case TYPE_U8:
-            case TYPE_C8:
-            case TYPE_I32:
-            case TYPE_DATE:
-            case TYPE_TIME:
-            case TYPE_I64:
-            case TYPE_TIMESTAMP:
-            case TYPE_F64:
-            case TYPE_SYMBOL:
-            case TYPE_GUID:
-            case TYPE_LIST:
-                const vectorValue = this.deserializeVector(type);
-                return { value: vectorValue, typeName };
-            case TYPE_TABLE:
-                return { value: this.deserializeTable(), typeName };
-            case TYPE_DICT:
-                return { value: this.deserializeDict(), typeName };
-            case TYPE_ERR:
-                return { value: this.deserializeError(), typeName };
-            default:
-                throw new Error(`Unsupported type: ${type}`);
-        }
+        // Peek the type byte for the name; deserialize() consumes it
+        const type = this.buf.readInt8(this.offset);
+        return { value: this.deserialize(), typeName: this.getTypeName(type) };
     }
 
     private getTypeName(type: number): string {
@@ -533,11 +612,12 @@ class Deserializer {
             [TYPE_NULL]: 'Null',
             [-TYPE_B8]: 'B8', [TYPE_B8]: 'B8',
             [-TYPE_U8]: 'U8', [TYPE_U8]: 'U8',
-            [-TYPE_I16]: 'I16',
+            [-TYPE_I16]: 'I16', [TYPE_I16]: 'I16',
             [-TYPE_I32]: 'I32', [TYPE_I32]: 'I32',
             [-TYPE_I64]: 'I64', [TYPE_I64]: 'I64',
+            [-TYPE_F32]: 'F32', [TYPE_F32]: 'F32',
             [-TYPE_F64]: 'F64', [TYPE_F64]: 'F64',
-            [-TYPE_C8]: 'C8', [TYPE_C8]: 'C8',
+            [-TYPE_STR]: 'String', [TYPE_STR]: 'String',
             [-TYPE_SYMBOL]: 'Symbol', [TYPE_SYMBOL]: 'Symbol',
             [-TYPE_DATE]: 'Date', [TYPE_DATE]: 'Date',
             [-TYPE_TIME]: 'Time', [TYPE_TIME]: 'Time',
@@ -547,7 +627,10 @@ class Deserializer {
             [TYPE_TABLE]: 'Table',
             [TYPE_DICT]: 'Dict',
             [TYPE_ERR]: 'Error',
-            [TYPE_LAMBDA]: 'Lambda'
+            [TYPE_LAMBDA]: 'Lambda',
+            [TYPE_UNARY]: 'Lambda',
+            [TYPE_BINARY]: 'Lambda',
+            [TYPE_VARY]: 'Lambda'
         };
         return typeNames[type] || 'Unknown';
     }
@@ -564,14 +647,38 @@ class Deserializer {
         };
     }
 
+    private deserializeLambda(): RayforceFunction {
+        this.readUInt8(); // skip attrs
+        const params = this.deserialize();
+        this.deserialize(); // body — consumed but not represented
+
+        return {
+            _type: 'function',
+            name: null,
+            params
+        };
+    }
+
+    private deserializeBuiltin(): RayforceFunction {
+        // Builtins serialize by name: null-terminated string, no attrs byte
+        return {
+            _type: 'function',
+            name: this.readNullTerminatedString(),
+            params: null
+        };
+    }
+
     private deserializeError(): RayforceError {
-        const code = this.readInt8();
-        const msg = this.deserialize();
-        
+        // 8 bytes: up to 7 chars of packed ASCII code, NUL-padded
+        const raw = this.readBuffer(8);
+        let end = raw.indexOf(0);
+        if (end < 0) end = raw.length;
+        const code = raw.toString('ascii', 0, end);
+
         return {
             _type: 'error',
             code,
-            message: typeof msg === 'string' ? msg : String(msg)
+            message: code
         };
     }
 }
@@ -594,10 +701,10 @@ export class RayforceIpcClient {
         this.port = port;
     }
 
-    async connect(timeout: number = 5000): Promise<void> {
+    async connect(timeout: number = 5000, auth?: { user?: string; password?: string }): Promise<void> {
         return new Promise((resolve, reject) => {
             let settled = false;
-            
+
             const settle = (fn: () => void) => {
                 if (!settled) {
                     settled = true;
@@ -606,15 +713,19 @@ export class RayforceIpcClient {
                 }
             };
 
-            const timeoutHandle = setTimeout(() => {
+            const fail = (err: Error) => {
                 settle(() => {
                     this.disconnect();
-                    reject(new Error(`Connection timeout after ${timeout}ms`));
+                    reject(err);
                 });
+            };
+
+            const timeoutHandle = setTimeout(() => {
+                fail(new Error(`Connection timeout after ${timeout}ms`));
             }, timeout);
 
             this.socket = new net.Socket();
-            
+
             this.socket.on('error', (err) => {
                 settle(() => {
                     this.connected = false;
@@ -636,33 +747,85 @@ export class RayforceIpcClient {
                 }
             });
 
-            this.socket.connect(this.port, this.host, () => {
-                const handshake = Buffer.alloc(2);
-                handshake[0] = RAYFORCE_VERSION;
-                handshake[1] = 0;
-                
-                this.socket!.write(handshake, (writeErr) => {
-                    if (writeErr) {
-                        settle(() => reject(writeErr));
+            // Handshake: send [version, 0]; server replies [version, auth_required].
+            // If auth is required, send [len]["user:password\0"] and expect a
+            // single 0x00 status byte back.  Replies may arrive split across
+            // 'data' events, so accumulate bytes until each phase is complete.
+            let hsBuffer = Buffer.alloc(0);
+            let hsPhase: 'version' | 'auth' = 'version';
+
+            const enterStreaming = (leftover: Buffer) => {
+                this.connected = true;
+                this.socket!.removeListener('data', onHandshakeData);
+                this.socket!.on('data', (d) => this.handleData(d));
+
+                if (leftover.length > 0) {
+                    this.responseBuffer = Buffer.concat([this.responseBuffer, leftover]);
+                    this.tryProcessResponse();
+                }
+                resolve();
+            };
+
+            const onHandshakeData = (data: Buffer) => {
+                hsBuffer = Buffer.concat([hsBuffer, data]);
+
+                if (hsPhase === 'version') {
+                    if (hsBuffer.length < 2) return;
+
+                    const version = hsBuffer[0];
+                    const authRequired = hsBuffer[1];
+                    if (version !== RAYFORCE_WIRE_VERSION) {
+                        fail(new Error(`Server speaks wire protocol v${version}, this client requires v${RAYFORCE_WIRE_VERSION}`));
                         return;
                     }
-                    
-                    this.socket!.once('data', (data: Buffer) => {
-                        if (data.length >= 1 && data[0] === RAYFORCE_VERSION) {
-                            settle(() => {
-                                this.connected = true;
-                                this.socket!.on('data', (d) => this.handleData(d));
-                                
-                                if (data.length > 1) {
-                                    this.responseBuffer = Buffer.concat([this.responseBuffer, data.subarray(1)]);
-                                    this.tryProcessResponse();
-                                }
-                                resolve();
-                            });
-                        } else {
-                            settle(() => reject(new Error('Invalid handshake response')));
-                        }
-                    });
+
+                    hsBuffer = hsBuffer.subarray(2);
+
+                    if (authRequired === 0x00) {
+                        settle(() => enterStreaming(hsBuffer));
+                        return;
+                    }
+                    if (authRequired !== 0x01) {
+                        fail(new Error('Invalid handshake response'));
+                        return;
+                    }
+
+                    if (!auth || !auth.password) {
+                        fail(new AuthRequiredError());
+                        return;
+                    }
+
+                    // "user:password" with the null terminator counted in len
+                    const cred = Buffer.from(`${auth.user || ''}:${auth.password}\0`, 'utf8');
+                    if (cred.length > 255) {
+                        fail(new Error('Credentials too long'));
+                        return;
+                    }
+
+                    hsPhase = 'auth';
+                    this.socket!.write(Buffer.concat([Buffer.from([cred.length]), cred]));
+                }
+
+                if (hsPhase === 'auth') {
+                    if (hsBuffer.length < 1) return;
+
+                    if (hsBuffer[0] !== 0x00) {
+                        fail(new Error('Authentication rejected'));
+                        return;
+                    }
+                    settle(() => enterStreaming(hsBuffer.subarray(1)));
+                }
+            };
+
+            this.socket.connect(this.port, this.host, () => {
+                const handshake = Buffer.from([RAYFORCE_WIRE_VERSION, 0]);
+
+                this.socket!.write(handshake, (writeErr) => {
+                    if (writeErr) {
+                        fail(writeErr);
+                        return;
+                    }
+                    this.socket!.on('data', onHandshakeData);
                 });
             });
         });
@@ -774,10 +937,13 @@ export class RayforceIpcClient {
             const totalSize = HEADER_SIZE + Number(header.size);
             if (this.responseBuffer.length < totalSize) break;
 
-            const payload = this.responseBuffer.subarray(HEADER_SIZE, totalSize);
+            const rawPayload = this.responseBuffer.subarray(HEADER_SIZE, totalSize);
             this.responseBuffer = this.responseBuffer.subarray(totalSize);
 
             try {
+                const payload = (header.flags & IPC_FLAG_COMPRESSED) !== 0
+                    ? decompressPayload(rawPayload)
+                    : rawPayload;
                 const deserializer = new Deserializer(payload);
                 const value = deserializer.deserialize();
 
@@ -843,6 +1009,9 @@ export function formatValue(value: RayforceValue): string {
         }
         if (value._type === 'error') {
             return `'${value.message}`;
+        }
+        if (value._type === 'function') {
+            return value.name || 'fn';
         }
         if (value._type === 'table') {
             return formatTable(value);

--- a/src/replPanel.ts
+++ b/src/replPanel.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { RayforceIpcClient, isError, RayforceValue, RayforceDict, RayforceError } from './rayforceIpc';
+import { RayforceIpcClient, AuthRequiredError, isError, RayforceValue, RayforceDict, RayforceError } from './rayforceIpc';
 import { formatValueHtml, formatValueText, getPrettyPrintStyles, detectType, defaultConfig, PaginationInfo } from './prettyPrint';
 
 interface EnvEntry {
@@ -115,7 +115,23 @@ export class RayforceReplPanel {
         this.port = port;
 
         try {
-            await newClient.connect(5000);
+            try {
+                await newClient.connect(5000);
+            } catch (err) {
+                // Server requires credentials: prompt once and retry
+                if (!(err instanceof AuthRequiredError) || this.connectionVersion !== currentVersion) {
+                    throw err;
+                }
+                const password = await vscode.window.showInputBox({
+                    prompt: `Password for ${host}:${port}`,
+                    password: true,
+                    ignoreFocusOut: true
+                });
+                if (password === undefined || this.connectionVersion !== currentVersion) {
+                    throw err;
+                }
+                await newClient.connect(5000, { password });
+            }
 
             // If connection changed while we were connecting, clean up this connection
             if (this.connectionVersion !== currentVersion) {
@@ -228,31 +244,38 @@ export class RayforceReplPanel {
         }
 
         try {
-            // Batch request: get keys and types in just 2 IPC calls instead of N+1
-            const keysResult = await this.ipcClient.execute('(key (env))');
-            
+            // Batch request: get names and types in just 2 IPC calls instead
+            // of N+1.  `env` is a unary builtin — the argument is ignored.
+            const keysResult = await this.ipcClient.execute('(key (env 0))');
+
             if (this.connectionVersion !== currentVersion) return;
 
-            // Get all types in one call using (map type (value (env)))
-            const typesResult = await this.ipcClient.execute('(map type (value (env)))');
-            
+            const typesResult = await this.ipcClient.execute('(map type (value (env 0)))');
+
             if (this.connectionVersion !== currentVersion) return;
 
-            // Parse keys (list of symbols)
-            const keys = this.parseEnvKeys(keysResult);
-            
-            // Parse types (list of symbols in same order as keys)
-            const types = this.parseEnvTypes(typesResult);
+            // Names and types arrive in the same env order — pair them up
+            // before any filtering or sorting so they stay aligned
+            const names = this.parseSymbolList(keysResult);
+            const types = this.parseSymbolList(typesResult);
 
-            // Zip keys and types together
             const entries: EnvEntry[] = [];
-            for (let i = 0; i < keys.length; i++) {
+            for (let i = 0; i < names.length; i++) {
+                const name = names[i];
+                const type = types[i] || '?';
+                // Skip internal namespaces (.sys, .ipc, ...) and builtins
+                // (type '?') — the panel lists user-defined bindings
+                if (name.startsWith('.') || type === '?') {
+                    continue;
+                }
                 entries.push({
-                    name: keys[i],
-                    type: types[i] || '?',
+                    name,
+                    type,
                     value: '' // Don't fetch value - only fetch on inspect
                 });
             }
+
+            entries.sort((a, b) => a.name.localeCompare(b.name));
 
             this.envData = entries;
         } catch {
@@ -263,48 +286,23 @@ export class RayforceReplPanel {
         this.updateWebview();
     }
 
-    private parseEnvTypes(result: RayforceValue): string[] {
-        const types: string[] = [];
-        
-        if (Array.isArray(result)) {
-            for (const item of result) {
-                if (typeof item === 'symbol') {
-                    types.push(Symbol.keyFor(item) || String(item).replace('Symbol(', '').replace(')', ''));
-                } else if (typeof item === 'string') {
-                    types.push(item);
-                } else {
-                    types.push(String(item));
-                }
-            }
-        }
-        
-        return types;
-    }
+    private parseSymbolList(result: RayforceValue): string[] {
+        const items: string[] = [];
 
-    private parseEnvKeys(result: RayforceValue): string[] {
-        const keys: string[] = [];
-        
         if (Array.isArray(result)) {
             for (const item of result) {
-                let name: string | null = null;
                 if (typeof item === 'symbol') {
                     // Rayfall symbols are JavaScript Symbol primitives
-                    name = Symbol.keyFor(item) || String(item);
+                    items.push(Symbol.keyFor(item) || String(item));
                 } else if (typeof item === 'string') {
-                    name = item;
-                }
-                
-                // Skip internal/system variables (starting with .)
-                if (name && !name.startsWith('.')) {
-                    keys.push(name);
+                    items.push(item);
+                } else {
+                    items.push(String(item));
                 }
             }
         }
-        
-        // Sort alphabetically
-        keys.sort((a, b) => a.localeCompare(b));
-        
-        return keys;
+
+        return items;
     }
 
     private parseTypeName(result: RayforceValue): string {
@@ -340,7 +338,7 @@ export class RayforceReplPanel {
             if (this.connectionVersion !== currentVersion) return;
 
             // Check for wrapper parse errors
-            if (isError(result) && (result as RayforceError).code === 2) {
+            if (isError(result) && (result as RayforceError).code === 'parse') {
                 useRawFallback = true;
             } else if (!useRawFallback) {
                 let actualResult: RayforceValue = result;
@@ -517,8 +515,8 @@ export class RayforceReplPanel {
             // Check if the wrapper itself caused a parse error - fall back to raw
             if (isError(result)) {
                 const errResult = result as RayforceError;
-                // Parse errors (code 2) likely mean wrapper syntax issue - try raw
-                if (errResult.code === 2) {
+                // Parse errors likely mean wrapper syntax issue - try raw
+                if (errResult.code === 'parse') {
                     useRawFallback = true;
                 } else {
                     // Other errors are from the user's command, show them


### PR DESCRIPTION
## Problem

The extension's IPC client implements the early-2025 wire format (version 1). Current RayforceDB speaks `RAY_SERDE_WIRE_VERSION 3` and refuses any other version at handshake (`src/core/ipc.c` closes the socket without a reply), so the extension cannot connect to a modern server at all — every attempt ends with "Connection closed".

## What changed

Everything is scoped to speaking the current wire protocol; no behavioral redesign.

**Handshake** (`rayforceIpc.ts`)
- Send/expect version `3`; a version mismatch now produces an explicit error message.
- Implement the auth leg of the handshake (`[len]"user:password\0"` → status byte). The REPL panel prompts for a password (masked input) when the server was started with `-u`.

**Serialization**
- Statements are sent as STR atoms (`-13` + flags + i64 length + utf8 bytes) — the shape the server's sync handler evaluates as source text.

**Deserialization**
- v3 type ids (SYMBOL 6→12, F64 10→7, DATE 7→8, TIME 8→9, TIMESTAMP 9→10; new F32=6 and STR=13).
- Atoms carry a flags byte (bit 0 = typed null) between type and value bytes.
- STR atoms/vectors, F32 and I16 vectors, LAMBDA (params decoded, rendered as `fn [...]`), builtins by name (UNARY/BINARY/VARY 101–103).
- Errors are an 8-byte packed ASCII code (`'type`, `'parse`, …) instead of `[i8 code][message value]`. `RayforceError.code` is now a string; the REPL's parse-error fallback keys on `'parse'` (the numeric enum it used had drifted from the engine anyway).
- Responses larger than 2000 bytes arrive delta+RLE compressed (header flag `0x01`, u32 uncompressed-size prefix) — ported `ray_ipc_decompress`.

**Environment panel** (`replPanel.ts`)
- `(env)` is a unary builtin now — the panel calls `(env 0)`.
- env includes builtins these days, so names and types are paired up *before* filtering/sorting (they used to be filtered and sorted independently, which misaligned name↔type), and builtins (type `?`) and dot-namespaces are hidden — the panel lists user bindings only.

## Testing

`npm run test:ipc` (new `scripts/test-ipc.js`) spawns a local rayforce (plain and `-u` auth) and drives the compiled client end-to-end: atoms (incl. typed nulls and utf8), vectors, mixed lists, dicts, tables, compressed frames (100k-element vector, 5k-row table), error codes (`'type`, `'parse`), builtins/lambdas, async messages, the exact preview-wrapper expression the REPL sends for pagination, env name/type pairing, and all three auth outcomes (no password / wrong password / correct password).

31/31 passing against current rayforce master. Set `RAYFORCE_BIN=/path/to/rayforce` if the binary is not on PATH.

## Notes

- Pre-v3 servers are no longer supported: they refuse this client at handshake exactly as current servers refuse the old client, and the failure is an explicit error either way.
- Follow-ups I'd propose separately (pre-existing, unrelated to the protocol): pre-2000 timestamps render garbage in the three timestamp formatters (truncating BigInt division + negative remainder), the REPL title/status hardcodes `localhost` even for remote connections, and concurrent `execute()` calls share a single pending-response slot.
