### PR TITLE
fix(format): render pre-2000 timestamps correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -265,6 +265,7 @@
     "vscode:prepublish": "npm run compile",
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
+    "test:format": "node scripts/test-format.js",
     "package": "vsce package"
   },
   "devDependencies": {

--- a/scripts/test-format.js
+++ b/scripts/test-format.js
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+/**
+ * Unit test for timestamp formatting (no server needed).
+ *
+ * Expected strings are the native REPL renderings (fmt_timestamp /
+ * ts_to_parts in rayforce src/lang/format.c); the 2024 case is a
+ * round-trip of a literal parsed by a live rayforce instance.
+ *
+ * Run `npm run compile` first, then `npm run test:format`.
+ */
+
+const path = require('path');
+
+const { formatValue } = require(path.join(__dirname, '..', 'out', 'rayforceIpc.js'));
+const { formatValueText, formatValueHtml } = require(path.join(__dirname, '..', 'out', 'prettyPrint.js'));
+
+const ts = (value) => ({ _type: 'timestamp', value });
+
+const cases = [
+    // Pre-2000 (negative) values — the regression this test guards:
+    // truncating BigInt division put these on the wrong day with a
+    // negative nanosecond field ("2000.01.01D00:00:00.0000000-1")
+    [-1n, '1999.12.31D23:59:59.999999999'],
+    [-500000000n, '1999.12.31D23:59:59.500000000'],
+    [-86400000000000n + 123n, '1999.12.31D00:00:00.000000123'],
+    [-946684800000000000n, '1970.01.01D00:00:00.000000000'], // Unix epoch
+    // 2000+ values — behavior unchanged
+    [0n, '2000.01.01D00:00:00.000000000'],
+    [1234567890n, '2000.01.01D00:00:01.234567890'],
+    [763821045123456789n, '2024.03.15D12:30:45.123456789'],
+];
+
+let passed = 0;
+let failed = 0;
+
+function check(name, got, want) {
+    if (got === want) {
+        passed++;
+        console.log(`  ok    ${name}`);
+    } else {
+        failed++;
+        console.log(`  FAIL  ${name} — got "${got}", want "${want}"`);
+    }
+}
+
+for (const [value, want] of cases) {
+    check(`formatValue(${value}n)`, formatValue(ts(value)), want);
+    check(`formatValueText(${value}n)`, formatValueText(ts(value)), want);
+
+    const html = formatValueHtml(ts(value));
+    check(`formatValueHtml(${value}n)`, html.includes(`>${want}<`) ? want : html, want);
+}
+
+// Null timestamp still renders as the typed null literal
+check('formatValueText(0Np)', formatValueText(ts(-9223372036854775808n)), '0Np');
+
+console.log(`\n${passed} passed, ${failed} failed`);
+process.exit(failed === 0 ? 0 : 1);

--- a/src/prettyPrint.ts
+++ b/src/prettyPrint.ts
@@ -3,7 +3,7 @@
  * Renders Rayforce types as beautiful HTML for the REPL webview
  */
 
-import { RayforceValue, RayforceTable, RayforceDict, RayforceError, RayforceDate, RayforceTime, RayforceTimestamp } from './rayforceIpc';
+import { RayforceValue, RayforceTable, RayforceDict, RayforceError, RayforceDate, RayforceTime, RayforceTimestamp, formatTimestampString } from './rayforceIpc';
 
 // ============================================================================
 // Configuration
@@ -475,23 +475,8 @@ function formatTimestampHtml(timestamp: RayforceTimestamp): string {
     if (timestamp.value === NULL_I64) {
         return `<span class="rf-null">0Np</span>`;
     }
-    
-    // Convert nanoseconds since 2000-01-01 to milliseconds
-    const milliseconds = Number(timestamp.value / BigInt(1000000));
-    const jsDate = new Date(milliseconds + UT_EPOCH_SHIFT_MS);
-    
-    const year = jsDate.getUTCFullYear();
-    const month = String(jsDate.getUTCMonth() + 1).padStart(2, '0');
-    const day = String(jsDate.getUTCDate()).padStart(2, '0');
-    const hours = String(jsDate.getUTCHours()).padStart(2, '0');
-    const minutes = String(jsDate.getUTCMinutes()).padStart(2, '0');
-    const seconds = String(jsDate.getUTCSeconds()).padStart(2, '0');
-    
-    // Extract nanoseconds from the original value
-    const nanos = Number(timestamp.value % BigInt(1000000000));
-    const nanosStr = String(nanos).padStart(9, '0');
-    
-    return `<span class="rf-timestamp">${year}.${month}.${day}D${hours}:${minutes}:${seconds}.${nanosStr}</span>`;
+
+    return `<span class="rf-timestamp">${formatTimestampString(timestamp.value)}</span>`;
 }
 
 // Format RayforceDate object (plain text)
@@ -538,23 +523,8 @@ function formatTimestampText(timestamp: RayforceTimestamp): string {
     if (timestamp.value === NULL_I64) {
         return '0Np';
     }
-    
-    // Convert nanoseconds since 2000-01-01 to milliseconds
-    const milliseconds = Number(timestamp.value / BigInt(1000000));
-    const jsDate = new Date(milliseconds + UT_EPOCH_SHIFT_MS);
-    
-    const year = jsDate.getUTCFullYear();
-    const month = String(jsDate.getUTCMonth() + 1).padStart(2, '0');
-    const day = String(jsDate.getUTCDate()).padStart(2, '0');
-    const hours = String(jsDate.getUTCHours()).padStart(2, '0');
-    const minutes = String(jsDate.getUTCMinutes()).padStart(2, '0');
-    const seconds = String(jsDate.getUTCSeconds()).padStart(2, '0');
-    
-    // Extract nanoseconds from the original value
-    const nanos = Number(timestamp.value % BigInt(1000000000));
-    const nanosStr = String(nanos).padStart(9, '0');
-    
-    return `${year}.${month}.${day}D${hours}:${minutes}:${seconds}.${nanosStr}`;
+
+    return formatTimestampString(timestamp.value);
 }
 
 function formatArray(arr: RayforceValue[], config: PrettyPrintConfig, depth: number, pagination?: PaginationInfo): string {

--- a/src/rayforceIpc.ts
+++ b/src/rayforceIpc.ts
@@ -172,7 +172,7 @@ class Serializer {
 const RAYFORCE_EPOCH_YEAR = 2000;
 const UT_EPOCH_SHIFT_MS = 946684800 * 1000; // milliseconds from Unix epoch (1970-01-01) to Rayforce epoch (2000-01-01)
 const MSECS_IN_DAY = 24 * 60 * 60 * 1000;
-const NSECS_IN_DAY = 24 * 60 * 60 * 1000000000;
+const NSECS_IN_DAY = BigInt(24 * 60 * 60) * BigInt(1000000000);
 
 // NULL value constants (from rayforce.h)
 const NULL_I32 = -2147483648; // 0x80000000
@@ -1002,26 +1002,46 @@ function formatTime(time: RayforceTime): string {
 }
 
 /**
+ * Format a timestamp value (i64 nanoseconds since 2000-01-01) as
+ * YYYY.MM.DDDHH:MM:SS.nnnnnnnnn, exactly like the native REPL
+ * (ts_to_parts in format.c).
+ *
+ * The day/intra-day split must be floored, not truncated: BigInt `/` and
+ * `%` truncate toward zero, so for pre-2000 (negative) values a plain
+ * split lands on the wrong day and yields a negative nanosecond remainder
+ * (rendered as garbage like "2000.01.01D00:00:00.0000000-1").
+ */
+export function formatTimestampString(nanoseconds: bigint): string {
+    let days = nanoseconds / NSECS_IN_DAY;
+    let span = nanoseconds % NSECS_IN_DAY;
+    if (span < BigInt(0)) {
+        days -= BigInt(1);
+        span += NSECS_IN_DAY;
+    }
+
+    // Days since 2000-01-01 → calendar date (exact: |days| * MSECS_IN_DAY
+    // is far below 2^53)
+    const jsDate = new Date(Number(days) * MSECS_IN_DAY + UT_EPOCH_SHIFT_MS);
+    const year = String(jsDate.getUTCFullYear()).padStart(4, '0');
+    const month = String(jsDate.getUTCMonth() + 1).padStart(2, '0');
+    const day = String(jsDate.getUTCDate()).padStart(2, '0');
+
+    const secs = span / BigInt(1000000000);
+    const nanos = span % BigInt(1000000000);
+    const hours = String(secs / BigInt(3600)).padStart(2, '0');
+    const minutes = String((secs % BigInt(3600)) / BigInt(60)).padStart(2, '0');
+    const seconds = String(secs % BigInt(60)).padStart(2, '0');
+    const nanosStr = String(nanos).padStart(9, '0');
+
+    return `${year}.${month}.${day}D${hours}:${minutes}:${seconds}.${nanosStr}`;
+}
+
+/**
  * Format a Rayforce Timestamp (YYYY.MM.DDDHH:MM:SS.nnnnnnnnn)
  * Based on timestamp_fmt_into in format.c
  */
 function formatTimestamp(timestamp: RayforceTimestamp): string {
-    // Convert nanoseconds since 2000-01-01 to milliseconds
-    const milliseconds = Number(timestamp.value / BigInt(1000000));
-    const jsDate = new Date(milliseconds + UT_EPOCH_SHIFT_MS);
-    
-    const year = jsDate.getUTCFullYear();
-    const month = String(jsDate.getUTCMonth() + 1).padStart(2, '0');
-    const day = String(jsDate.getUTCDate()).padStart(2, '0');
-    const hours = String(jsDate.getUTCHours()).padStart(2, '0');
-    const minutes = String(jsDate.getUTCMinutes()).padStart(2, '0');
-    const seconds = String(jsDate.getUTCSeconds()).padStart(2, '0');
-    
-    // Extract nanoseconds from the original value
-    const nanos = Number(timestamp.value % BigInt(1000000000));
-    const nanosStr = String(nanos).padStart(9, '0');
-    
-    return `${year}.${month}.${day}D${hours}:${minutes}:${seconds}.${nanosStr}`;
+    return formatTimestampString(timestamp.value);
 }
 
 /**


### PR DESCRIPTION
## Problem

Timestamps are `i64` nanoseconds since 2000-01-01, so pre-2000 instants are **negative**. All three timestamp formatters — `formatTimestamp` (`rayforceIpc.ts`) and `formatTimestampText` / `formatTimestampHtml` (`prettyPrint.ts`) — split the value into day / intra-day parts with BigInt `/` and `%`, which **truncate toward zero**. For negative values this lands on the wrong calendar day and leaves a negative nanosecond field, rendering garbage:

```
-1n          ->  2000.01.01D00:00:00.0000000-1
-500000000n  ->  1999.12.31D23:59:59.-500000000
```

instead of `1999.12.31D23:59:59.999999999` / `...59.500000000`.

(Listed as a follow-up in #3.)

## What changed

- Replace the three duplicated formatters with one exported `formatTimestampString()` that mirrors the native formatter (`ts_to_parts` in `format.c`): **floor** the day split by borrowing a day when the intra-day remainder is negative, then derive `H:M:S.ns` from the resulting non-negative remainder.
- `prettyPrint.ts` (text + HTML/webview) now delegates to the same function, so every rendering path stays in sync.
- 2000+ values are unaffected; the null timestamp still renders as `0Np`.

## Testing

The branch adds `scripts/test-format.js` (`npm run test:format`, no server needed) covering negative values, the Unix epoch (`-946684800000000000n` → `1970.01.01D00:00:00.000000000`), zero, and a 2024 literal round-tripped through a live rayforce instance; expected strings are the native REPL renderings. The fix was additionally fuzz-checked against an independent port of `ts_to_parts` on 200k random values.
