### PR TITLE
fix(repl): show the actual host in the panel title and status bar

### DIFF
--- a/src/replPanel.ts
+++ b/src/replPanel.ts
@@ -613,8 +613,8 @@ export class RayforceReplPanel {
 
     private updateWebview(): void {
         this.panel.webview.html = this.getHtmlContent();
-        this.panel.title = this.port
-            ? `Rayfall REPL — localhost:${this.port}`
+        this.panel.title = this.host && this.port
+            ? `Rayfall REPL — ${this.host}:${this.port}`
             : 'Rayfall REPL — Disconnected';
     }
 
@@ -1198,7 +1198,7 @@ export class RayforceReplPanel {
         <div class="header">
             <div class="status">
                 <div class="status-indicator"></div>
-                <span class="status-text">${isConnected ? `localhost:${this.port}` : 'Disconnected'}</span>
+                <span class="status-text">${isConnected ? this.escapeHtml(`${this.host}:${this.port}`) : 'Disconnected'}</span>
             </div>
             <div class="header-actions">
                 <button class="header-btn ${this.showEnv ? 'active' : ''}" onclick="toggleEnv()" title="Toggle Environment Panel">


### PR DESCRIPTION
## Problem

The REPL panel title and the webview status line hardcoded `localhost`, so connecting to a saved **remote** instance (e.g. `192.168.1.100:5111`) still labeled the panel `Rayfall REPL — localhost:5111` and showed `localhost:5111` in the status bar — misleading, especially with several instances open.

(Listed as a follow-up in #3.)

## What changed

`src/replPanel.ts`:

- Panel title and status line now use the connected `this.host` instead of the literal `localhost`.
- The status-line host is HTML-escaped (`escapeHtml`), since the host string comes from user input and is interpolated into the webview HTML.
- The title still falls back to `Rayfall REPL — Disconnected` when host/port are unset.

## Testing

Display-only change confined to `replPanel.ts` (title + status-line strings); the disconnected fallback and all other behavior are unchanged.
