### PR TITLE
fix(ui): surface environment and webview state correctly

### DIFF
--- a/assets/processInfo.css
+++ b/assets/processInfo.css
@@ -1,0 +1,129 @@
+body {
+    font-family: var(--vscode-font-family);
+    font-size: var(--vscode-font-size);
+    color: var(--vscode-foreground);
+    margin: 0;
+    padding: 12px 16px;
+}
+
+body.empty-body {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    min-height: 120px;
+    padding: 16px;
+}
+
+.empty-state {
+    text-align: center;
+    opacity: 0.6;
+}
+
+.empty-icon {
+    font-size: 32px;
+    margin-bottom: 8px;
+}
+
+.empty-text {
+    font-size: 12px;
+    color: var(--vscode-descriptionForeground);
+}
+
+.header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 16px;
+    padding-bottom: 12px;
+    border-bottom: 1px solid var(--vscode-panel-border);
+}
+
+.logo {
+    width: 24px;
+    height: 24px;
+}
+
+.logo-light {
+    display: none;
+}
+
+.logo-dark {
+    display: block;
+}
+
+body.vscode-light .logo-light {
+    display: block;
+}
+
+body.vscode-light .logo-dark {
+    display: none;
+}
+
+.header-info {
+    flex: 1;
+}
+
+.instance-label {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--vscode-foreground);
+    margin-bottom: 4px;
+}
+
+.instance-type {
+    font-size: 11px;
+    color: var(--vscode-descriptionForeground);
+}
+
+.status-dot {
+    width: 8px;
+    height: 8px;
+    background: var(--vscode-testing-iconPassed, #4caf50);
+    border-radius: 50%;
+    animation: pulse 2s ease-in-out infinite;
+}
+
+@keyframes pulse {
+    0%, 100% {
+        opacity: 1;
+    }
+
+    50% {
+        opacity: 0.5;
+    }
+}
+
+.info-section {
+    margin-top: 12px;
+}
+
+.info-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 8px 0;
+    border-bottom: 1px solid var(--vscode-panel-border);
+}
+
+.info-item:last-child {
+    border-bottom: none;
+}
+
+.info-label {
+    font-size: 11px;
+    color: var(--vscode-descriptionForeground);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.info-value {
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--vscode-foreground);
+    font-family: var(--vscode-editor-font-family, monospace);
+}
+
+.status-connected {
+    color: var(--vscode-testing-iconPassed, #4caf50);
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -464,7 +464,10 @@ export async function activate(context: vscode.ExtensionContext) {
 
     // Register completion provider for Rayfall files
     const completionProvider = vscode.languages.registerCompletionItemProvider(
-        { language: 'rayfall' },
+        [
+            { scheme: 'file', language: 'rayfall' },
+            { scheme: 'untitled', language: 'rayfall' }
+        ],
         new RayforceCompletionProvider(),
         '(', "'", ' '  // Trigger on (, ', and space
     );

--- a/src/instancesProvider.ts
+++ b/src/instancesProvider.ts
@@ -36,7 +36,7 @@ export class RayforceInstanceItem extends vscode.TreeItem {
                 `**Port:** \`${process.port}\`\n\n` +
                 `**PID:** \`${process.pid}\`\n\n` +
                 `**Command:** \`${process.command} ${process.args}\`\n\n` +
-                `---\n_Click to reconnect or use context menu_`
+                `---\n_Click to open REPL or use context menu_`
             );
             // Make connected instance more prominent
             this.resourceUri = vscode.Uri.parse(`rayforce://connected/${process.port}`);
@@ -54,11 +54,17 @@ export class RayforceInstanceItem extends vscode.TreeItem {
         
         this.contextValue = isConnected ? 'rayforceInstanceConnected' : 'rayforceInstance';
         
-        this.command = {
-            command: 'rayforce.connectToInstance',
-            title: 'Connect to Instance',
-            arguments: [this]
-        };
+        this.command = isConnected
+            ? {
+                command: 'rayforce.openRepl',
+                title: 'Open REPL',
+                arguments: [this]
+            }
+            : {
+                command: 'rayforce.connectToInstance',
+                title: 'Connect to Instance',
+                arguments: [this]
+            };
     }
 }
 
@@ -375,4 +381,3 @@ export class RayforceInstancesProvider implements vscode.TreeDataProvider<Instan
         this.statusBarItem.dispose();
     }
 }
-

--- a/src/processInfoProvider.ts
+++ b/src/processInfoProvider.ts
@@ -22,7 +22,7 @@ export class ProcessInfoProvider implements vscode.WebviewViewProvider {
         this.view = webviewView;
 
         webviewView.webview.options = {
-            enableScripts: true,
+            enableScripts: false,
             localResourceRoots: [this.extensionUri]
         };
 
@@ -50,6 +50,10 @@ export class ProcessInfoProvider implements vscode.WebviewViewProvider {
         const logoBlackUri = this.view?.webview.asWebviewUri(
             vscode.Uri.joinPath(this.extensionUri, 'assets', 'logo_black.svg')
         );
+        const styleUri = this.view?.webview.asWebviewUri(
+            vscode.Uri.joinPath(this.extensionUri, 'assets', 'processInfo.css')
+        );
+        const cspSource = this.view?.webview.cspSource || '';
 
         if (!this.connectedInstance) {
             return `<!DOCTYPE html>
@@ -57,33 +61,10 @@ export class ProcessInfoProvider implements vscode.WebviewViewProvider {
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <style>
-        body {
-            font-family: var(--vscode-font-family);
-            font-size: var(--vscode-font-size);
-            padding: 16px;
-            color: var(--vscode-foreground);
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            justify-content: center;
-            min-height: 120px;
-        }
-        .empty-state {
-            text-align: center;
-            opacity: 0.6;
-        }
-        .empty-icon {
-            font-size: 32px;
-            margin-bottom: 8px;
-        }
-        .empty-text {
-            font-size: 12px;
-            color: var(--vscode-descriptionForeground);
-        }
-    </style>
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src ${cspSource}; style-src ${cspSource}; script-src 'none';">
+    <link href="${styleUri}" rel="stylesheet">
 </head>
-<body>
+<body class="empty-body">
     <div class="empty-state">
         <div class="empty-icon">○</div>
         <div class="empty-text">No instance connected</div>
@@ -101,93 +82,8 @@ export class ProcessInfoProvider implements vscode.WebviewViewProvider {
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <style>
-        body {
-            font-family: var(--vscode-font-family);
-            font-size: var(--vscode-font-size);
-            padding: 12px 16px;
-            color: var(--vscode-foreground);
-            margin: 0;
-        }
-
-        .header {
-            display: flex;
-            align-items: center;
-            gap: 10px;
-            margin-bottom: 16px;
-            padding-bottom: 12px;
-            border-bottom: 1px solid var(--vscode-panel-border);
-        }
-
-        .logo {
-            width: 24px;
-            height: 24px;
-        }
-
-        .logo-light { display: none; }
-        .logo-dark { display: block; }
-        body.vscode-light .logo-light { display: block; }
-        body.vscode-light .logo-dark { display: none; }
-
-        .header-info {
-            flex: 1;
-        }
-
-        .instance-label {
-            font-size: 14px;
-            font-weight: 600;
-            color: var(--vscode-foreground);
-            margin-bottom: 4px;
-        }
-
-        .instance-type {
-            font-size: 11px;
-            color: var(--vscode-descriptionForeground);
-        }
-
-        .status-dot {
-            width: 8px;
-            height: 8px;
-            background: var(--vscode-testing-iconPassed, #4caf50);
-            border-radius: 50%;
-            animation: pulse 2s ease-in-out infinite;
-        }
-
-        @keyframes pulse {
-            0%, 100% { opacity: 1; }
-            50% { opacity: 0.5; }
-        }
-
-        .info-section {
-            margin-top: 12px;
-        }
-
-        .info-item {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            padding: 8px 0;
-            border-bottom: 1px solid var(--vscode-panel-border);
-        }
-
-        .info-item:last-child {
-            border-bottom: none;
-        }
-
-        .info-label {
-            font-size: 11px;
-            color: var(--vscode-descriptionForeground);
-            text-transform: uppercase;
-            letter-spacing: 0.5px;
-        }
-
-        .info-value {
-            font-size: 12px;
-            font-weight: 500;
-            color: var(--vscode-foreground);
-            font-family: var(--vscode-editor-font-family, monospace);
-        }
-    </style>
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src ${cspSource}; style-src ${cspSource}; script-src 'none';">
+    <link href="${styleUri}" rel="stylesheet">
 </head>
 <body>
     <div class="header">
@@ -211,7 +107,7 @@ export class ProcessInfoProvider implements vscode.WebviewViewProvider {
         </div>
         <div class="info-item">
             <span class="info-label">Status</span>
-            <span class="info-value" style="color: var(--vscode-testing-iconPassed, #4caf50)">● Connected</span>
+            <span class="info-value status-connected">● Connected</span>
         </div>
     </div>
 </body>
@@ -227,4 +123,3 @@ export class ProcessInfoProvider implements vscode.WebviewViewProvider {
             .replace(/'/g, '&#039;');
     }
 }
-

--- a/src/replPanel.ts
+++ b/src/replPanel.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { randomBytes } from 'crypto';
 import { RayforceIpcClient, AuthRequiredError, isError, RayforceValue, RayforceDict, RayforceError } from './rayforceIpc';
 import { formatValueHtml, formatValueText, getPrettyPrintStyles, detectType, defaultConfig, PaginationInfo } from './prettyPrint';
 
@@ -32,6 +33,7 @@ export class RayforceReplPanel {
     private port: number | null = null;
     private history: HistoryEntry[] = [];
     private envData: EnvEntry[] = [];
+    private envError: string | null = null;
     private showEnv: boolean = true;
     private envWidth: number = 280;
     private connectionVersion: number = 0;  // Track connection changes to abort stale operations
@@ -156,6 +158,7 @@ export class RayforceReplPanel {
             this.host = null;
             this.port = null;
             this.envData = [];
+            this.envError = null;
             this.updateWebview();
             throw err;
         }
@@ -173,6 +176,7 @@ export class RayforceReplPanel {
         this.host = null;
         this.port = null;
         this.envData = [];
+        this.envError = null;
     }
 
     public isConnected(): boolean {
@@ -233,12 +237,14 @@ export class RayforceReplPanel {
 
         if (!this.ipcClient) {
             this.envData = [];
+            this.envError = null;
             this.updateWebview();
             return;
         }
         
         if (!this.ipcClient.isConnected()) {
             this.envData = [];
+            this.envError = null;
             this.updateWebview();
             return;
         }
@@ -249,10 +255,22 @@ export class RayforceReplPanel {
             const keysResult = await this.ipcClient.execute('(key (env 0))');
 
             if (this.connectionVersion !== currentVersion) return;
+            if (isError(keysResult)) {
+                this.envData = [];
+                this.envError = this.formatEnvError(keysResult);
+                this.updateWebview();
+                return;
+            }
 
             const typesResult = await this.ipcClient.execute('(map type (value (env 0)))');
 
             if (this.connectionVersion !== currentVersion) return;
+            if (isError(typesResult)) {
+                this.envData = [];
+                this.envError = this.formatEnvError(typesResult);
+                this.updateWebview();
+                return;
+            }
 
             // Names and types arrive in the same env order — pair them up
             // before any filtering or sorting so they stay aligned
@@ -278,12 +296,18 @@ export class RayforceReplPanel {
             entries.sort((a, b) => a.name.localeCompare(b.name));
 
             this.envData = entries;
+            this.envError = null;
         } catch {
             if (this.connectionVersion !== currentVersion) return;
             this.envData = [];
+            this.envError = 'Environment unavailable';
         }
 
         this.updateWebview();
+    }
+
+    private formatEnvError(error: RayforceError): string {
+        return `Environment unavailable: ${error.message || error.code}`;
     }
 
     private parseSymbolList(result: RayforceValue): string[] {
@@ -624,6 +648,8 @@ export class RayforceReplPanel {
         const logoWhiteUri = this.panel.webview.asWebviewUri(
             vscode.Uri.joinPath(this.extensionUri, 'assets', 'logo_white.svg')
         );
+        const cspSource = this.panel.webview.cspSource;
+        const nonce = randomBytes(16).toString('base64');
 
         const historyHtml = this.history.map(item => {
             if (item.isSystem) {
@@ -659,14 +685,16 @@ export class RayforceReplPanel {
                 return '';
             }
         }).join('');
+        const envHtml = this.renderEnvContent(isConnected);
 
         return `<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src ${cspSource}; style-src ${cspSource} 'nonce-${nonce}'; script-src 'nonce-${nonce}';">
     <title>Rayfall REPL</title>
-    <style>
+    <style nonce="${nonce}">
         ${getPrettyPrintStyles()}
         
         :root {
@@ -847,6 +875,10 @@ export class RayforceReplPanel {
             text-align: center;
             color: var(--text-secondary);
             font-size: 12px;
+        }
+
+        .env-empty.error {
+            color: var(--error);
         }
 
         .status {
@@ -1199,11 +1231,11 @@ export class RayforceReplPanel {
                 <span class="status-text">${isConnected ? this.escapeHtml(`${this.host}:${this.port}`) : 'Disconnected'}</span>
             </div>
             <div class="header-actions">
-                <button class="header-btn ${this.showEnv ? 'active' : ''}" onclick="toggleEnv()" title="Toggle Environment Panel">
+                <button class="header-btn ${this.showEnv ? 'active' : ''}" data-action="toggle-env" title="Toggle Environment Panel">
                     ${this.showEnv ? '▶ Env' : 'Env ◀'}
                 </button>
-                <button class="header-btn" onclick="clearHistory()">Clear</button>
-                ${isConnected ? '<button class="header-btn" onclick="disconnect()">Disconnect</button>' : ''}
+                <button class="header-btn" data-action="clear-history">Clear</button>
+                ${isConnected ? '<button class="header-btn" data-action="disconnect">Disconnect</button>' : ''}
             </div>
         </div>
 
@@ -1238,7 +1270,7 @@ export class RayforceReplPanel {
                             spellcheck="false"
                         />
                     </div>
-                    <button class="submit-btn" onclick="executeCommand()" ${isConnected ? '' : 'disabled'}>
+                    <button class="submit-btn" data-action="execute-command" ${isConnected ? '' : 'disabled'}>
                         Run
                     </button>
                 </div>
@@ -1252,24 +1284,16 @@ export class RayforceReplPanel {
         <div class="env-header">
             <span class="env-title">Environment</span>
             <div class="env-actions">
-                <button class="env-btn" onclick="refreshEnv()" title="Refresh">⟳</button>
+                <button class="env-btn" data-action="refresh-env" title="Refresh">⟳</button>
             </div>
         </div>
         <div class="env-content">
-            ${this.envData.length === 0
-                    ? `<div class="env-empty">${isConnected ? 'No variables defined' : 'Not connected'}</div>`
-                    : this.envData.map(entry => `
-                    <div class="env-item" onclick="inspectVar('${entry.name.replace(/'/g, "\\'")}')" title="${this.escapeHtml(entry.value)}">
-                        <span class="env-item-name">${this.escapeHtml(entry.name)}</span>
-                        <span class="env-item-type">${entry.type}</span>
-                    </div>
-                `).join('')
-                }
+            ${envHtml}
         </div>
     </div>
     ` : ''}
 
-    <script>
+    <script nonce="${nonce}">
         const vscode = acquireVsCodeApi();
         const input = document.getElementById('command-input');
         const history = document.getElementById('history');
@@ -1865,6 +1889,19 @@ export class RayforceReplPanel {
             vscode.postMessage({ command: 'refreshEnv' });
         }
 
+        document.querySelector('[data-action="toggle-env"]')?.addEventListener('click', toggleEnv);
+        document.querySelector('[data-action="clear-history"]')?.addEventListener('click', clearHistory);
+        document.querySelector('[data-action="disconnect"]')?.addEventListener('click', disconnect);
+        document.querySelector('[data-action="execute-command"]')?.addEventListener('click', executeCommand);
+        document.querySelector('[data-action="refresh-env"]')?.addEventListener('click', refreshEnv);
+
+        document.querySelectorAll('[data-inspect-var]').forEach((item) => {
+            item.addEventListener('click', () => {
+                const name = item.getAttribute('data-inspect-var');
+                if (name) inspectVar(name);
+            });
+        });
+
         // Environment panel resize
         const envPanel = document.getElementById('env-panel');
         const resizeHandle = document.getElementById('env-resize-handle');
@@ -2151,6 +2188,23 @@ export class RayforceReplPanel {
         return result;
     }
 
+    private renderEnvContent(isConnected: boolean): string {
+        if (this.envError) {
+            return `<div class="env-empty error">${this.escapeHtml(this.envError)}</div>`;
+        }
+
+        if (this.envData.length === 0) {
+            return `<div class="env-empty">${isConnected ? 'No variables defined' : 'Not connected'}</div>`;
+        }
+
+        return this.envData.map(entry => `
+                    <div class="env-item" data-inspect-var="${this.escapeHtml(entry.name)}" title="${this.escapeHtml(entry.value)}">
+                        <span class="env-item-name">${this.escapeHtml(entry.name)}</span>
+                        <span class="env-item-type">${this.escapeHtml(entry.type)}</span>
+                    </div>
+                `).join('');
+    }
+
     public dispose(): void {
         RayforceReplPanel.currentPanel = undefined;
 
@@ -2168,4 +2222,3 @@ export class RayforceReplPanel {
         }
     }
 }
-


### PR DESCRIPTION
## Summary
- surface Environment panel IPC failures instead of showing an empty variable list
- make connected instance rows open the REPL while keeping disconnect as the inline action
- tighten webview CSP handling and move Process Info styles into a packaged asset
- restrict Rayfall completions to file and untitled documents

## Tests
- npm run compile
- node scripts/test-format.js
- RAYFORCE_BIN=/Users/evgenbyelozorov/Documents/ClickUpTask/bin/rayforce node scripts/test-ipc.js