### PR TITLE
fix(auth): prompt for Rayforce username

### DIFF
--- a/scripts/test-ipc.js
+++ b/scripts/test-ipc.js
@@ -182,6 +182,17 @@ async function testAuth(port) {
     } finally {
         goodCreds.disconnect();
     }
+
+    const userCreds = new RayforceIpcClient(HOST, port);
+    try {
+        await userCreds.connect(3000, { user: 'root', password: 'testpw' });
+        const v = await userCreds.execute('(+ 2 3)');
+        ok('auth: accepted with user and password', v === 5n, show(v));
+    } catch (err) {
+        ok('auth: accepted with user and password', false, err.message);
+    } finally {
+        userCreds.disconnect();
+    }
 }
 
 async function main() {

--- a/src/replPanel.ts
+++ b/src/replPanel.ts
@@ -122,15 +122,23 @@ export class RayforceReplPanel {
                 if (!(err instanceof AuthRequiredError) || this.connectionVersion !== currentVersion) {
                     throw err;
                 }
+                const user = await vscode.window.showInputBox({
+                    prompt: `User for ${host}:${port}`,
+                    value: 'root',
+                    ignoreFocusOut: true
+                });
+                if (user === undefined || this.connectionVersion !== currentVersion) {
+                    throw err;
+                }
                 const password = await vscode.window.showInputBox({
-                    prompt: `Password for ${host}:${port}`,
+                    prompt: `Password for ${user || 'server'}@${host}:${port}`,
                     password: true,
                     ignoreFocusOut: true
                 });
                 if (password === undefined || this.connectionVersion !== currentVersion) {
                     throw err;
                 }
-                await newClient.connect(5000, { password });
+                await newClient.connect(5000, { user: user.trim() || undefined, password });
             }
 
             // If connection changed while we were connecting, clean up this connection


### PR DESCRIPTION
## Summary
- ask for a Rayforce username when an IPC server requires authentication
- keep root as the default user while still allowing an empty username for password-only servers
- add an IPC regression test for user/password credential frames

## Verification
- reproduced localhost:5001 returning domain with password-only auth
- verified localhost:5001 returns normal results with user=root and the same password

## Tests
- npm run compile
- node scripts/test-format.js
- RAYFORCE_BIN=/Users/evgenbyelozorov/Documents/ClickUpTask/bin/rayforce node scripts/test-ipc.js